### PR TITLE
Flannel deployment updated

### DIFF
--- a/master.sh
+++ b/master.sh
@@ -4,6 +4,6 @@ set -e
 kubeadm config images pull
 kubeadm init --pod-network-cidr=10.244.0.0/16 \
         --token ${TOKEN} --apiserver-advertise-address=${MASTER_IP}
-KUBECONFIG=/etc/kubernetes/admin.conf kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/a70459be0084506e4ec919aa1c114638878db11b/Documentation/kube-flannel.yml
+KUBECONFIG=/etc/kubernetes/admin.conf kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/master/Documentation/kube-flannel.yml
 
 sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf taint node master node-role.kubernetes.io/master:NoSchedule-


### PR DESCRIPTION
Flannel deployment was failed due to DaemonSet API version extensions/v1beta1 deprecated.
Hence updated flannel deployment from master branch.